### PR TITLE
Bugfix: Grabbing modifiers without modmask doesn't work always

### DIFF
--- a/simpleswitcher.c
+++ b/simpleswitcher.c
@@ -1001,7 +1001,7 @@ void grab_key(unsigned int modmask, KeySym key)
 	grab_keycode(modmask, keycode);
 }
 
-void grab_modifier(unsigned int modmask, KeyCode * keycodes)
+void resolve_modifiers(unsigned int modmask, KeyCode * keycodes)
 {
 	int modidx = -1;
 
@@ -1139,9 +1139,9 @@ int main(int argc, char *argv[])
 	parse_key(config_menu_dkey, &desktop_windows_modmask, &desktop_windows_keysym);
 
 	// bind key combos
-	grab_modifier(all_windows_modmask, all_windows_modifiers);
+	resolve_modifiers(all_windows_modmask, all_windows_modifiers);
 	if ( desktop_windows_modmask != all_windows_modmask )
-			grab_modifier(desktop_windows_modmask, desktop_windows_modifiers);
+		resolve_modifiers(desktop_windows_modmask, desktop_windows_modifiers);
 	grab_key(all_windows_modmask, all_windows_keysym);
 	grab_key(desktop_windows_modmask, desktop_windows_keysym);
 


### PR DESCRIPTION
Testing simpleswitcher in Xnest, Xephyr and a plain X instance revealed
that grabbing a modifier key without modmask does not always work
properly. Therefore AnyModifier is set as modmask.
