### PR TITLE
Fix vim modelines

### DIFF
--- a/simpleswitcher.c
+++ b/simpleswitcher.c
@@ -1,4 +1,4 @@
-/* vim:noexpandtab:softtabstop=0: */
+/* vim: set noexpandtab softtabstop=0: */
 /* simpleswitcher
 
 MIT/X11 License

--- a/textbox.c
+++ b/textbox.c
@@ -1,4 +1,4 @@
-/* vim:noexpandtab:softtabstop=0: */
+/* vim: set noexpandtab softtabstop=0: */
 /*
 
 MIT/X11 License


### PR DESCRIPTION
Sorry, got it wrong last time. Gave an error on vim startup. There are
basically two types of modelines for vim. One for use with comments
with finishing delimiter (e.g. */) and one for those without (e.g. //)
